### PR TITLE
Add custom error for license error

### DIFF
--- a/hissw/environment.py
+++ b/hissw/environment.py
@@ -12,7 +12,7 @@ from jinja2 import (Environment as Env,
 from scipy.io import readsav
 
 from .read_config import defaults
-from .util import SSWIDLError
+from .util import SSWIDLError, IDLLicenseError
 
 
 class Environment(object):
@@ -143,5 +143,7 @@ class Environment(object):
         # have to check it for certain keywords to see if an error occurred
         if 'execution halted' in stderr.lower():
             raise SSWIDLError(stderr)
+        if 'failed to acquire license' in stderr.lower():
+            raise IDLLicenseError(stderr)
         if verbose:
             print(f'{stderr}\n{stdout}')

--- a/hissw/util.py
+++ b/hissw/util.py
@@ -9,3 +9,9 @@ class SSWIDLError(Exception):
     """
     pass
     
+
+class IDLLicenseError(Exception):
+    """
+    An error to raise when IDL cannot find a license
+    """
+    pass


### PR DESCRIPTION
Fixes #9 

This throws a custom exception when an IDL license can't be found rather than blowing up when the `.sav` results file can't be found.