### PR TITLE
Add option to run without ssw

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,10 @@ $ git clone https://github.com/wtbarnes/hissw.git
 $ cd hissw && python -m pip install -e[all,test]
 ```
 
-and then run the tests to make sure everything is working alright,
-```
-$ pytest
+and then run the tests to make sure everything is working alright. Note that you must specify paths to SSW and IDL appropriately.
+
+```shell
+$ pytest --ssw-home=<path to top of SSW tree> --idl-home=<path to top level dir of IDL install>
 ```
 
 **Note: hissw relies on executing several shell commands. This has not been tested on Windows.** 
@@ -54,4 +55,5 @@ If you use `hissw` in your work, please use the following citation,
 
 ## Reporting Issues and Contributing
 
-Open an [issue on GitHub](https://github.com/wtbarnes/hissw/issues) to report a problem. [Pull requests](https://github.com/wtbarnes/hissw/pulls) welcome.
+Open an [issue on GitHub](https://github.com/wtbarnes/hissw/issues) to report a problem.
+[Pull requests](https://github.com/wtbarnes/hissw/pulls) welcome.

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,21 @@
+"""
+Test setup
+"""
+import pytest
+
+
+def pytest_addoption(parser):
+    parser.addoption('--idl-home', action='store', default=None,
+                     help='Path to top level IDL directory')
+    parser.addoption('--ssw-home', action='store', default=None,
+                     help='Path to top of SSW tree')
+
+
+@pytest.fixture
+def idl_home(request):
+    return request.config.getoption('--idl-home')
+
+
+@pytest.fixture
+def ssw_home(request):
+    return request.config.getoption('--ssw-home')

--- a/hissw/read_config.py
+++ b/hissw/read_config.py
@@ -3,13 +3,8 @@ Read some default options if possible
 """
 
 import os
+import configparser
 
-try:
-    # Python 3
-    import configparser
-except ImportError:
-    # Python 2
-    import ConfigParser as configparser
 
 defaults = {}
 defaults['hissw_home'] = os.path.join(os.environ['HOME'], '.hissw')

--- a/hissw/templates/startup.sh
+++ b/hissw/templates/startup.sh
@@ -4,8 +4,10 @@ setenv SSW {{ ssw_home }}
 # Set SSW instruments
 setenv SSW_INSTR "{{ ssw_packages | join(' ') }}"
 # Setup needed environment variables
+{% if ssw_home is not none %}
 source $SSW/gen/setup/setup.ssw
+{% endif %}
 # Setup IDL environment
 setenv IDL_DIR {{ idl_home }}
 # Startup SSW IDL
-sswidl {{ command_filename }}
+{{ executable }} {{ command_filename }}

--- a/hissw/tests/test_hissw.py
+++ b/hissw/tests/test_hissw.py
@@ -11,8 +11,8 @@ run_kwargs = {'verbose': True}
 
 
 @pytest.fixture
-def hissw_env_blank():
-    return hissw.Environment()
+def hissw_env_blank(idl_home, ssw_home):
+    return hissw.Environment(ssw_home=ssw_home, idl_home=idl_home)
 
 
 def test_exception(hissw_env_blank):
@@ -52,7 +52,7 @@ def test_no_ssw(hissw_env_blank):
     assert results['array'].shape == (n, n)
 
 
-def test_aia_response_functions():
+def test_aia_response_functions(idl_home, ssw_home):
     """
     Compute AIA response functions using AIA packages in SSW
     """
@@ -67,7 +67,8 @@ def test_aia_response_functions():
     resp335 = response.a335.tresp
     '''
     args = {'flags': ['temp', 'dn', 'timedepend_date', 'evenorm']}
-    hissw_env = hissw.Environment(ssw_packages=['sdo/aia'], ssw_paths=['aia'])
+    hissw_env = hissw.Environment(idl_home=idl_home, ssw_home=ssw_home,
+                                  ssw_packages=['sdo/aia'], ssw_paths=['aia'])
     results = hissw_env.run(script, args=args, **run_kwargs)
     assert 'resp94' in results
     assert 'resp131' in results
@@ -105,3 +106,9 @@ def test_default_ssw_var(hissw_env_blank):
     """
     res = hissw_env_blank.run(script)
     assert res['foo'].decode('utf-8') == hissw_env_blank.ssw_home
+
+
+def test_idl_only(idl_home):
+    bare_idl = hissw.Environment(idl_home=idl_home, idl_only=True)
+    res = bare_idl.run('a = 1+1')
+    assert res['a'] == 2


### PR DESCRIPTION
Fixes #17

By passing in `idl_only=True` to `Environment`, you can skip any SSW setup commands such that this can be run without having an SSW install.