### PR TITLE
Allow headers and footers in idl environment

### DIFF
--- a/hissw/templates/procedure.pro
+++ b/hissw/templates/procedure.pro
@@ -1,6 +1,6 @@
 PRO hissw_procedure
     ;run user script
-    {{ script }}
+    {{ _script }}
     ;save workspace or desired variables
-    save,{% for var in save_vars %}{{ var }},{% endfor %}filename='{{ save_filename }}'
+    save,{% for var in _save_vars %}{{ var }},{% endfor %}filename='{{ _save_filename }}'
 END

--- a/hissw/tests/test_hissw.py
+++ b/hissw/tests/test_hissw.py
@@ -152,3 +152,18 @@ def test_custom_filters(idl_home):
 def test_invalid_script(idl_env):
     with pytest.raises(ValueError, match='Input script must either be a string or path to a script.'):
         _ = idl_env.run(None)
+
+
+def test_custom_header_footer(idl_home):
+    header = 'foo = {{ a }}'
+    footer = 'bar = {{ a }} + {{ b }}'
+    env_custom = hissw.Environment(idl_home=idl_home, idl_only=True,
+                                   header=header, footer=footer)
+    script = '''
+    print, {{ a }}
+    print, {{ b }}
+    '''
+    args = {'a': 1, 'b': 2}
+    result = env_custom.run(script, args=args)
+    assert result['foo'] == args['a']
+    assert result['bar'] == args['a'] + args['b']


### PR DESCRIPTION
Fixes #26 

Custom headers and footers can now be passed to `Environment` with the keywords `header` and `footer`.
These are prepended and appended, respectively, to each script passed into `run`.