### PR TITLE
Add filter to force preservation of precision in floating point values

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -43,7 +43,7 @@ $ pytest
 
 ## Bridging the IDL-Python Gap the Bad Way...
 
-hissw is a hack, albeit a clever one. In general, the methodology employed here (round-tripping everything in memory to disk) is a *terrible idea*. There's no shared memory between Python and IDL or anything fancy like that. If you're interested in something more complicated (and harder to install), you may want to check out the more official [Python-to-IDL bridge](https://www.harrisgeospatial.com/docs/Python.html).
+`hissw` is a hack, albeit a clever one. In general, the methodology employed here (round-tripping everything in memory to disk) is a *terrible idea*. There's no shared memory between Python and IDL or anything fancy like that. If you're interested in something more complicated (and harder to install), you may want to check out the more official [Python-to-IDL bridge](https://www.harrisgeospatial.com/docs/Python.html).
 
 ## Word(s) of Caution
 
@@ -54,3 +54,18 @@ hissw is a hack, albeit a clever one. In general, the methodology employed here 
 * Widgets and plotting will (likely) **not** work
 * This has **not** been tested extensively against all SSW/IDL functionality. There are likely many cases where hissw will not work. [Bug reports](https://github.com/wtbarnes/hissw/issues) and [pull requests](https://github.com/wtbarnes/hissw/pulls) welcome!
 
+## A Note on Preserving Precision between Python and IDL
+
+`hissw` relies on string representations of Python objects when inserting values into the resulting IDL script.
+However, [the default string representation of Python floats is truncated well below the actual floating point precision.](https://docs.python.org/3/tutorial/floatingpoint.html#floating-point-arithmetic-issues-and-limitations)
+This can result in a loss of precision when injecting floating point values into IDL from Python as documented in [this issue](https://github.com/wtbarnes/hissw/issues/31).
+Thus, to ensure that floating point values are accurately represented, hissw provides the `force_double_precision` filter.
+This filter can be used as follows, where `var` is a (scalar or array) variable containing a floating point value,
+
+```IDL
+var = {{ var | force_double_precision }}
+```
+
+This filter uses the builtin [`float.as_integer_ratio`](https://docs.python.org/3/library/stdtypes.html#float.as_integer_ratio) method to represent floating point values as division operations between integer values
+to ensure that precision is not lost in the string representation Python values in the resulting IDL script.
+If used in combination with other filters, this filter should be used last.

--- a/hissw/environment.py
+++ b/hissw/environment.py
@@ -59,6 +59,7 @@ class Environment(object):
         self.env.filters['to_unit'] = units_filter
         self.env.filters['log10'] = log10_filter
         self.env.filters['string_list'] = string_list_filter
+        self.env.filters['force_double_precision'] = force_double_precision_filter
         if filters is not None:
             for k, v in filters.items():
                 self.env.filters[k] = v

--- a/hissw/filters.py
+++ b/hissw/filters.py
@@ -47,7 +47,8 @@ def force_double_precision_filter(value):
     Thus, to preserve precision, this filter uses the `as_integer_ratio` method
     to represent floating point values as division operations between integer values
     to ensure that precision is preserved when passing floating point values from
-    IDL into Python.
+    IDL into Python. When used in combination with other filters, this filter should
+    be used last as it forces a conversion to a list of strings.
     """
     if isinstance(value, (np.ndarray, list)):
         str_list = [force_double_precision_filter(x) for x in value]


### PR DESCRIPTION
Fixes #31 

With this PR, the output from the code snippet shown in the above issue should now be,

```idl
List of random numbers which were double precision in Python:
      0.38701972      0.39714535      0.41908539      0.49686550      0.79868530
      0.84018735      0.45899108      0.94885019      0.67142288      0.28960234
Size of first entry:            0           5           1
List of random numbers which were extended precision in Python:
      0.65914494      0.83123126      0.98263299      0.91399852      0.54612130
      0.54969574      0.68435703      0.97690220      0.23865732      0.42071446
Size of first entry:            0           5           1
```